### PR TITLE
add biochatter-next docker compose file

### DIFF
--- a/.bioserver.env.template
+++ b/.bioserver.env.template
@@ -1,0 +1,13 @@
+# If .bioserver.env doesn't provide OPENAI setup, customers need to set OPENAI API key in website
+# OPENAI_API_KEY=
+
+# Optional (Azure), 
+# Besides OPENAI_API_KEY, the following envs should be set for Azure
+# OPENAI_API_TYPE=
+# OPENAI_DEPLOYMENT_NAME=
+# OPENAI_MODEL=
+# OPENAI_API_VERSION=
+# AZURE_OPENAI_ENDPOINT=
+# AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME=
+# AZURE_OPENAI_EMBEDDINGS_MODEL=
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 biocypher-*
 .vscode
 data/*
+*.env
+volumes/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/config/biochatter-next.yaml
+++ b/config/biochatter-next.yaml
@@ -7,7 +7,7 @@ KnowledgeGraph:
       description: "This knowledge graph contains information on Patients, Genes, SequenceVariants, CopyNumberAlterations, BiologicalPathways, and Drugs. It also contains relationships between these entities."
 
 VectorStore:
-  enabled: true
+  enabled: false
   servers:
     - server: local
       address: standalone

--- a/config/biochatter-next.yaml
+++ b/config/biochatter-next.yaml
@@ -2,12 +2,12 @@ KnowledgeGraph:
   enabled: true
   servers:
     - server: decider-genetic-kg
-      address: deploy 
+      address: deploy
       port: 7687
       description: "This knowledge graph contains information on Patients, Genes, SequenceVariants, CopyNumberAlterations, BiologicalPathways, and Drugs. It also contains relationships between these entities."
 
 VectorStore:
-  enabled: false
+  enabled: true
   servers:
     - server: local
       address: standalone

--- a/config/biochatter-next.yaml
+++ b/config/biochatter-next.yaml
@@ -2,8 +2,8 @@ KnowledgeGraph:
   enabled: true
   servers:
     - server: decider-genetic-kg
-      address: 10.95.224.94 # biocypher
-      port: 47687
+      address: deploy 
+      port: 7687
       description: "This knowledge graph contains information on Patients, Genes, SequenceVariants, CopyNumberAlterations, BiologicalPathways, and Drugs. It also contains relationships between these entities."
 
 VectorStore:

--- a/docker-compose-next.yml
+++ b/docker-compose-next.yml
@@ -64,6 +64,49 @@ services:
       import:
         condition: service_completed_successfully
 
+  etcd:
+    container_name: milvus-etcd
+    image: quay.io/coreos/etcd:v3.5.5
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+      - ETCD_SNAPSHOT_COUNT=50000
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+
+  minio:
+    container_name: milvus-minio
+    image: minio/minio:RELEASE.2022-03-17T06-34-49Z
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
+    command: minio server /minio_data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  standalone:
+    container_name: milvus-standalone
+    image: milvusdb/milvus:v2.2.8
+    command: ["milvus", "run", "standalone"]
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    depends_on:
+      - "etcd"
+      - "minio"
+
   app:
     image: biocypher/biochatter-next:1.3.0
     container_name: app
@@ -71,6 +114,7 @@ services:
       - "3000:3000"
     depends_on:
       - "bioserver"
+      - "standalone"
     volumes:
       - ./tmp:/tmp
       - ./config:/config

--- a/docker-compose-next.yml
+++ b/docker-compose-next.yml
@@ -1,0 +1,88 @@
+version: '3.9'
+
+services:
+
+  build:
+    image: docker.io/slobentanzer/biocypher-base:1.0.0
+    container_name: build
+    volumes:
+      - biocypher_neo4j_volume:/usr/app/data
+      - .:/src/
+    command:
+      - /bin/bash
+      - /src/scripts/build.sh
+
+  import:
+    image: neo4j:4.4-enterprise
+    container_name: import
+    environment:
+      NEO4J_AUTH: none
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+      FILL_DB_ON_STARTUP: "yes"
+    volumes:
+      - biocypher_neo4j_volume:/data
+      - ./scripts/import.sh:/scripts/import.sh
+    command:
+      - /bin/bash
+      - /scripts/import.sh
+    depends_on:
+      build:
+        condition: service_completed_successfully
+
+  deploy:
+    image: neo4j:4.4-enterprise
+    container_name: deploy
+    volumes:
+      - biocypher_neo4j_volume:/data
+    environment:
+      NEO4J_dbms_security_auth__enabled: "false"
+      NEO4J_dbms_databases_default__to__read__only: "false"
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+    ports:
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:7687:7687"
+    depends_on:
+      import:
+        condition: service_completed_successfully
+  
+  bioserver:
+    container_name: biochatter-server
+    image: biocypher/biochatter-server:0.5.1
+    env_file:
+      - .bioserver.env
+    ports:
+      - 5001:5001
+    volumes:
+      - ./logs:/app/logs
+      - ./tmp:/tmp
+    environment:
+      - HOST=standalone
+      - PORT=19530
+      - KGHOST=deploy
+      - KGPORT=7687
+    depends_on:
+      import:
+        condition: service_completed_successfully
+
+  app:
+    image: biocypher/biochatter-next:1.3.0
+    container_name: app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - "bioserver"
+    volumes:
+      - ./tmp:/tmp
+      - ./config:/config
+    environment:
+      - BASE_URL=http://bioserver:5001
+      - CUSTOM_BIOCHATTER_NEXT_FILE=/config/biochatter-next.yaml
+
+volumes:
+  biocypher_neo4j_volume:
+
+
+networks:
+  default:
+    name: biochatter
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "decider-genetics"
-version = "0.3.0"
+version = "0.4.0"
 description = "KG pipeline for genetics workflows"
 authors = [
     "Sebastian Lobentanzer <sebastian.lobentanzer@gmail.com>",


### PR DESCRIPTION
### Abstract
This submission is to add docker compose file for biochatter-next

### Notes
As this docker compose file does not include milvus image, the vectorstore agent is disabled in config/biochatter-next.yaml